### PR TITLE
Update 404CTF ranking information

### DIFF
--- a/src/app/shared/informations/ctf.ts
+++ b/src/app/shared/informations/ctf.ts
@@ -1,7 +1,7 @@
 export const ctf = [
   {
     nomLogo: '404ctf',
-    description: '404CTF, organisé par la DGSE. Classement : 662 / 3267',
+    description: '404CTF, organisé par la DGSE. Classement : 662 / 3267 | 05-2024 - 538 / 2893 | 05-2025',
     date: '05-2024',
     site: 'https://www.404ctf.fr/'
   },


### PR DESCRIPTION
## Summary
- extend the 404CTF description with additional ranking info for 05-2025

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_6844310b2030832cb05714aee8479a66