### PR TITLE
Fix comment in badge class

### DIFF
--- a/src/app/shared/class/badge.ts
+++ b/src/app/shared/class/badge.ts
@@ -13,7 +13,7 @@ export class Badge {
     return 'https://img.shields.io/badge/' + nom + '-' + this.getColorFromText(nom) + '?logo=' + this.getLogoFromText(nom) + '&logoColor=white';
   }
 
-  // permet d'obtenir le long d'un logo à partir de son nom
+  // permet d'obtenir le nom d'un logo à partir de son nom
   getLogoFromText(nom: string) {
     nom = nom.toLowerCase();
     nom = nom.replaceAll('+', 'plus');


### PR DESCRIPTION
## Summary
- correct French typo in Badge.getLogoFromText comment

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: Module not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844342cf6a0832cad382b8af7f2612f