### PR TITLE
Update e2e test to check header title

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -7,8 +7,8 @@ describe('new App', () => {
     page = new AppPage();
   });
 
-  it('should be blank', () => {
+  it('should display header title', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toContain('Start with Ionic UI Components');
+    expect(page.getParagraphText()).toContain('Nicolas Barrat');
   });
 });

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -6,6 +6,6 @@ export class AppPage {
   }
 
   getParagraphText() {
-    return element(by.deepCss('app-root ion-content')).getText();
+    return element(by.deepCss('app-header .nom')).getText();
   }
 }


### PR DESCRIPTION
## Summary
- update e2e page object to read the header title
- check that the header displays "Nicolas Barrat"

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*
- `npm run e2e --silent` *(fails: tunneling socket could not be established)*

------
https://chatgpt.com/codex/tasks/task_b_6844342db158832cbf4c962135336cd3