### PR TITLE
Add comprehensive component tests

### DIFF
--- a/src/app/home/home.page.spec.ts
+++ b/src/app/home/home.page.spec.ts
@@ -1,16 +1,21 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, Platform } from '@ionic/angular';
 
 import { HomePage } from './home.page';
 
 describe('HomePage', () => {
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
+  let platformSpy: jasmine.SpyObj<Platform>;
 
   beforeEach(waitForAsync(() => {
+    platformSpy = jasmine.createSpyObj('Platform', ['is']);
+    platformSpy.is.and.returnValue(true);
+
     TestBed.configureTestingModule({
       declarations: [ HomePage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot()],
+      providers: [{ provide: Platform, useValue: platformSpy }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomePage);
@@ -20,5 +25,17 @@ describe('HomePage', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should detect desktop platform', () => {
+    expect(platformSpy.is).toHaveBeenCalledWith('desktop');
+    expect(component.isDesktop).toBeTrue();
+  });
+
+  it('should toggle afficheNom on scroll', () => {
+    component.eventScroll({detail: {scrollTop: 600}} as any);
+    expect(component.afficheNom).toBeTrue();
+    component.eventScroll({detail: {scrollTop: 400}} as any);
+    expect(component.afficheNom).toBeFalse();
   });
 });

--- a/src/app/home/home.page.spec.ts
+++ b/src/app/home/home.page.spec.ts
@@ -3,11 +3,17 @@ import { IonicModule, Platform } from '@ionic/angular';
 
 import { HomePage } from './home.page';
 
+// Unit tests for the HomePage component.
+// The platform service is mocked to simulate a desktop environment
+// and scroll events are tested to ensure the component toggles
+// the `afficheNom` property correctly.
+
 describe('HomePage', () => {
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
   let platformSpy: jasmine.SpyObj<Platform>;
 
+  // Configure the testing module and mock Platform
   beforeEach(waitForAsync(() => {
     platformSpy = jasmine.createSpyObj('Platform', ['is']);
     platformSpy.is.and.returnValue(true);
@@ -27,11 +33,13 @@ describe('HomePage', () => {
     expect(component).toBeTruthy();
   });
 
+  // Platform.is('desktop') should be called and isDesktop flag set
   it('should detect desktop platform', () => {
     expect(platformSpy.is).toHaveBeenCalledWith('desktop');
     expect(component.isDesktop).toBeTrue();
   });
 
+  // The afficheNom flag should toggle based on scroll position
   it('should toggle afficheNom on scroll', () => {
     component.eventScroll({detail: {scrollTop: 600}} as any);
     expect(component.afficheNom).toBeTrue();

--- a/src/app/shared/class/badge.spec.ts
+++ b/src/app/shared/class/badge.spec.ts
@@ -1,0 +1,26 @@
+import { Badge } from './badge';
+
+describe('Badge class', () => {
+  let badge: Badge;
+
+  beforeEach(() => {
+    badge = new Badge();
+  });
+
+  it('should convert text to logo format', () => {
+    expect(badge.getLogoFromText('C++')).toBe('cplusplus');
+  });
+
+  it('should return color from text', () => {
+    expect(badge.getColorFromText('Angular')).toBe('0F0F11');
+    expect(badge.getColorFromText('Bison')).toBe('181717');
+    expect(badge.getColorFromText('Unknown')).toBe('181717');
+  });
+
+  it('should build link', () => {
+    const link = badge.getLink('Angular');
+    expect(link).toBe(
+      'https://img.shields.io/badge/Angular-0F0F11?logo=angular&logoColor=white'
+    );
+  });
+});

--- a/src/app/shared/class/badge.spec.ts
+++ b/src/app/shared/class/badge.spec.ts
@@ -1,5 +1,8 @@
 import { Badge } from './badge';
 
+// Unit tests for the Badge helper class.
+// They verify logo formatting, color retrieval and link generation.
+
 describe('Badge class', () => {
   let badge: Badge;
 
@@ -7,16 +10,19 @@ describe('Badge class', () => {
     badge = new Badge();
   });
 
+  // getLogoFromText should handle special characters
   it('should convert text to logo format', () => {
     expect(badge.getLogoFromText('C++')).toBe('cplusplus');
   });
 
+  // getColorFromText should return matching color or a default
   it('should return color from text', () => {
     expect(badge.getColorFromText('Angular')).toBe('0F0F11');
     expect(badge.getColorFromText('Bison')).toBe('181717');
     expect(badge.getColorFromText('Unknown')).toBe('181717');
   });
 
+  // getLink builds a shield.io URL
   it('should build link', () => {
     const link = badge.getLink('Angular');
     expect(link).toBe(

--- a/src/app/shared/component/contact/contact.component.spec.ts
+++ b/src/app/shared/component/contact/contact.component.spec.ts
@@ -3,6 +3,10 @@ import { IonicModule } from '@ionic/angular';
 
 import { ContactComponent } from './contact.component';
 
+// Unit tests for the ContactComponent.
+// The delay method is stubbed so tests run synchronously and
+// the click handler behaviour is verified.
+
 describe('ContactComponent', () => {
   let component: ContactComponent;
   let fixture: ComponentFixture<ContactComponent>;
@@ -24,11 +28,13 @@ describe('ContactComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  // testMailOrTel should return input for known value and undefined otherwise
   it('should test testMailOrTel', () => {
     expect(component.testMailOrTel('Téléphone')).toBe('Téléphone');
     expect(component.testMailOrTel('Autre')).toBeUndefined();
   });
 
+  // click should update innerHTML, store the value and await delay
   it('should handle click', async () => {
     const event = { target: { innerHTML: 'abc' } } as any;
     await component.click(event, 'test');

--- a/src/app/shared/component/contact/contact.component.spec.ts
+++ b/src/app/shared/component/contact/contact.component.spec.ts
@@ -6,8 +6,10 @@ import { ContactComponent } from './contact.component';
 describe('ContactComponent', () => {
   let component: ContactComponent;
   let fixture: ComponentFixture<ContactComponent>;
+  let delaySpy: jasmine.Spy;
 
   beforeEach(waitForAsync(() => {
+    delaySpy = spyOn(ContactComponent.prototype, 'delay').and.returnValue(Promise.resolve());
     TestBed.configureTestingModule({
       declarations: [ ContactComponent ],
       imports: [IonicModule.forRoot()]
@@ -20,5 +22,18 @@ describe('ContactComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should test testMailOrTel', () => {
+    expect(component.testMailOrTel('Téléphone')).toBe('Téléphone');
+    expect(component.testMailOrTel('Autre')).toBeUndefined();
+  });
+
+  it('should handle click', async () => {
+    const event = { target: { innerHTML: 'abc' } } as any;
+    await component.click(event, 'test');
+    expect(event.target.innerHTML).toBe('test');
+    expect(component.affiche).toContain('test');
+    expect(delaySpy).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/component/header/header.component.spec.ts
+++ b/src/app/shared/component/header/header.component.spec.ts
@@ -8,8 +8,6 @@ describe('HeaderComponent', () => {
   let fixture: ComponentFixture<HeaderComponent>;
   let animationCtrlSpy: jasmine.SpyObj<AnimationController>;
   let animationSpy: any;
-  let querySpy: jasmine.Spy;
-  let scrollSpy: jasmine.Spy;
 
   beforeEach(waitForAsync(() => {
     animationSpy = {} as any;
@@ -20,9 +18,6 @@ describe('HeaderComponent', () => {
 
     animationCtrlSpy = jasmine.createSpyObj('AnimationController', ['create']);
     animationCtrlSpy.create.and.returnValue(animationSpy);
-
-    scrollSpy = jasmine.createSpy('scrollIntoView');
-    querySpy = spyOn(document, 'querySelector').and.returnValue({scrollIntoView: scrollSpy} as any);
 
     TestBed.configureTestingModule({
       declarations: [ HeaderComponent ],
@@ -62,8 +57,17 @@ describe('HeaderComponent', () => {
   });
 
   it('should scroll to section in goTo', () => {
-    querySpy.calls.reset();
+    const scrollSpy = jasmine.createSpy('scrollIntoView');
+    const realQuery = document.querySelector.bind(document);
+    const querySpy = spyOn(document, 'querySelector').and.callFake((selector: string) => {
+      if (selector === '#test') {
+        return { scrollIntoView: scrollSpy } as any;
+      }
+      return realQuery(selector);
+    });
+
     component.goTo('test');
+
     expect(querySpy).toHaveBeenCalledWith('#test');
     expect(scrollSpy).toHaveBeenCalledWith({behavior: 'smooth'});
   });

--- a/src/app/shared/component/header/header.component.spec.ts
+++ b/src/app/shared/component/header/header.component.spec.ts
@@ -3,12 +3,17 @@ import { IonicModule, AnimationController } from '@ionic/angular';
 
 import { HeaderComponent } from './header.component';
 
+// Tests for HeaderComponent.
+// AnimationController is fully mocked to check the animation chain
+// and navigation logic is verified.
+
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
   let animationCtrlSpy: jasmine.SpyObj<AnimationController>;
   let animationSpy: any;
 
+  // Setup component with a mocked AnimationController
   beforeEach(waitForAsync(() => {
     animationSpy = {} as any;
     animationSpy.addElement = jasmine.createSpy('addElement').and.returnValue(animationSpy);
@@ -34,6 +39,7 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  // ngOnChanges should trigger the correct animation
   it('should play animation on changes', () => {
     component.afficheNom = true;
     component.ngOnChanges();
@@ -56,6 +62,7 @@ describe('HeaderComponent', () => {
     ]);
   });
 
+  // goTo should scroll smoothly to the given element
   it('should scroll to section in goTo', () => {
     const scrollSpy = jasmine.createSpy('scrollIntoView');
     const realQuery = document.querySelector.bind(document);

--- a/src/app/shared/component/header/header.component.spec.ts
+++ b/src/app/shared/component/header/header.component.spec.ts
@@ -1,16 +1,33 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, AnimationController } from '@ionic/angular';
 
 import { HeaderComponent } from './header.component';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
+  let animationCtrlSpy: jasmine.SpyObj<AnimationController>;
+  let animationSpy: any;
+  let querySpy: jasmine.Spy;
+  let scrollSpy: jasmine.Spy;
 
   beforeEach(waitForAsync(() => {
+    animationSpy = {} as any;
+    animationSpy.addElement = jasmine.createSpy('addElement').and.returnValue(animationSpy);
+    animationSpy.duration = jasmine.createSpy('duration').and.returnValue(animationSpy);
+    animationSpy.keyframes = jasmine.createSpy('keyframes').and.returnValue(animationSpy);
+    animationSpy.play = jasmine.createSpy('play').and.returnValue(Promise.resolve());
+
+    animationCtrlSpy = jasmine.createSpyObj('AnimationController', ['create']);
+    animationCtrlSpy.create.and.returnValue(animationSpy);
+
+    scrollSpy = jasmine.createSpy('scrollIntoView');
+    querySpy = spyOn(document, 'querySelector').and.returnValue({scrollIntoView: scrollSpy} as any);
+
     TestBed.configureTestingModule({
       declarations: [ HeaderComponent ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot()],
+      providers: [{ provide: AnimationController, useValue: animationCtrlSpy }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
@@ -20,5 +37,34 @@ describe('HeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should play animation on changes', () => {
+    component.afficheNom = true;
+    component.ngOnChanges();
+    expect(animationCtrlSpy.create).toHaveBeenCalled();
+    expect(animationSpy.addElement).toHaveBeenCalled();
+    expect(animationSpy.duration).toHaveBeenCalledWith(500);
+    expect(animationSpy.keyframes).toHaveBeenCalledWith([
+      {offset: 0, opacity: '0'},
+      {offset: 1, opacity: '1'}
+    ]);
+    expect(animationSpy.play).toHaveBeenCalled();
+
+    animationSpy.addElement.calls.reset();
+    animationSpy.keyframes.calls.reset();
+    component.afficheNom = false;
+    component.ngOnChanges();
+    expect(animationSpy.keyframes).toHaveBeenCalledWith([
+      {offset: 0, opacity: '1'},
+      {offset: 1, opacity: '0'}
+    ]);
+  });
+
+  it('should scroll to section in goTo', () => {
+    querySpy.calls.reset();
+    component.goTo('test');
+    expect(querySpy).toHaveBeenCalledWith('#test');
+    expect(scrollSpy).toHaveBeenCalledWith({behavior: 'smooth'});
   });
 });

--- a/src/app/shared/component/menu/menu.component.spec.ts
+++ b/src/app/shared/component/menu/menu.component.spec.ts
@@ -15,8 +15,8 @@ describe('MenuComponent', () => {
 
     fixture = TestBed.createComponent(MenuComponent);
     component = fixture.componentInstance;
-    (component as any).menu = { el: { close: jasmine.createSpy('close') } };
     fixture.detectChanges();
+    component.menu = { el: { close: jasmine.createSpy('close') } } as any;
   }));
 
   it('should create', () => {

--- a/src/app/shared/component/menu/menu.component.spec.ts
+++ b/src/app/shared/component/menu/menu.component.spec.ts
@@ -6,8 +6,13 @@ import { MenuComponent } from './menu.component';
 describe('MenuComponent', () => {
   let component: MenuComponent;
   let fixture: ComponentFixture<MenuComponent>;
+  let querySpy: jasmine.Spy;
+  let scrollSpy: jasmine.Spy;
 
   beforeEach(waitForAsync(() => {
+    scrollSpy = jasmine.createSpy('scrollIntoView');
+    querySpy = spyOn(document, 'querySelector').and.returnValue({scrollIntoView: scrollSpy} as any);
+
     TestBed.configureTestingModule({
       declarations: [ MenuComponent ],
       imports: [IonicModule.forRoot()]
@@ -15,10 +20,18 @@ describe('MenuComponent', () => {
 
     fixture = TestBed.createComponent(MenuComponent);
     component = fixture.componentInstance;
+    (component as any).menu = { el: { close: jasmine.createSpy('close') } };
     fixture.detectChanges();
   }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should scroll to element and close menu', () => {
+    component.goTo('section');
+    expect(querySpy).toHaveBeenCalledWith('#section');
+    expect(scrollSpy).toHaveBeenCalledWith({behavior: 'smooth'});
+    expect((component as any).menu.el.close).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/component/menu/menu.component.spec.ts
+++ b/src/app/shared/component/menu/menu.component.spec.ts
@@ -3,10 +3,15 @@ import { IonicModule } from '@ionic/angular';
 
 import { MenuComponent } from './menu.component';
 
+// Tests for MenuComponent.
+// document.querySelector is partially mocked so scrolling can be
+// verified without interfering with Angular's internals.
+
 describe('MenuComponent', () => {
   let component: MenuComponent;
   let fixture: ComponentFixture<MenuComponent>;
 
+  // Initialize component and stub the menu close method
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ MenuComponent ],
@@ -23,6 +28,7 @@ describe('MenuComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  // goTo should scroll smoothly to the element and close the menu
   it('should scroll to element and close menu', () => {
     const scrollSpy = jasmine.createSpy('scrollIntoView');
     const realQuery = document.querySelector.bind(document);

--- a/src/app/shared/component/menu/menu.component.spec.ts
+++ b/src/app/shared/component/menu/menu.component.spec.ts
@@ -6,13 +6,8 @@ import { MenuComponent } from './menu.component';
 describe('MenuComponent', () => {
   let component: MenuComponent;
   let fixture: ComponentFixture<MenuComponent>;
-  let querySpy: jasmine.Spy;
-  let scrollSpy: jasmine.Spy;
 
   beforeEach(waitForAsync(() => {
-    scrollSpy = jasmine.createSpy('scrollIntoView');
-    querySpy = spyOn(document, 'querySelector').and.returnValue({scrollIntoView: scrollSpy} as any);
-
     TestBed.configureTestingModule({
       declarations: [ MenuComponent ],
       imports: [IonicModule.forRoot()]
@@ -29,7 +24,17 @@ describe('MenuComponent', () => {
   });
 
   it('should scroll to element and close menu', () => {
+    const scrollSpy = jasmine.createSpy('scrollIntoView');
+    const realQuery = document.querySelector.bind(document);
+    const querySpy = spyOn(document, 'querySelector').and.callFake((selector: string) => {
+      if (selector === '#section') {
+        return { scrollIntoView: scrollSpy } as any;
+      }
+      return realQuery(selector);
+    });
+
     component.goTo('section');
+
     expect(querySpy).toHaveBeenCalledWith('#section');
     expect(scrollSpy).toHaveBeenCalledWith({behavior: 'smooth'});
     expect((component as any).menu.el.close).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- enhance HomePage tests with platform mock and scroll behavior
- expand MenuComponent tests to check scrolling and menu closing
- fully mock HeaderComponent animations and add goTo test
- add ContactComponent interaction tests
- cover Badge class helpers

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_684441eee358832c83755d67209d63ce